### PR TITLE
fix: only use apps from deps if `cds-plugin-ui5` is present

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,10 +146,12 @@ export class cds_launchpad_plugin{
     // Read CDS project package
     const packagejson = JSON.parse(fs.readFileSync(cds.root + '/package.json').toString());
     let depsPaths = [];
-    try {
-      ({ depsPaths } = this.getAppsFromDependencies(packagejson));
-    } catch (error) {
-      cdsLaunchpadLogger.error(`Error while reading dependencies: ${error}`);
+    if (cds.env?.plugins !== undefined && cds.env?.plugins['cds-plugin-ui5']) {
+      try {
+        ({ depsPaths } = this.getAppsFromDependencies(packagejson));
+      } catch (error) {
+        cdsLaunchpadLogger.error(`Error while reading dependencies: ${error}`);
+      }
     }
 
     if(Array.isArray(packagejson.sapux)){


### PR DESCRIPTION
only show the apps that are included in the dependencies of the package.json when  is present