### PR TITLE
fix: Launchpad plugin path: keep namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,10 +169,9 @@ export class cds_launchpad_plugin{
 
         if (manifest["sap.flp"]?.type === 'plugin') {
             const component = appId;
-            const name = component.split('.').pop();
-            config.bootstrapPlugins[name] = {
+            config.bootstrapPlugins[component] = {
                 component,
-                url: name + "/webapp",
+                url: component + "/webapp",
                 'sap-ushell-plugin-type': 'RendererExtensions',
                 enabled: true
             }


### PR DESCRIPTION
Launchpad plugins path should follow URL approach defined for regular apps as stated in this file below: "cds-plugin-ui5 uses the appid as default route (combination namespace + component)"