### PR TITLE
feat: improved locale support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,19 +191,19 @@ export class cds_launchpad_plugin{
           i18nPath += i18nsetting;
         }
 
-        // define local to use
-        const local = null;
+        // define locale to use
+        const locale = null;
 
         // check for existing files
-        if(!local && options.locale && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`))) local = i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`)
-        if(!local && cds.user?.local && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) local = i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`) // would be great but only exists after CAP logic..
-        if(!local && req_locale.default(request) && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) local = i18nPath.replace(/(\.properties)$/, `_${req_locale.default(request)}$1`)
-        if(!local && cds.env.i18n.default_language && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) local = i18nPath.replace(/(\.properties)$/, `_${cds.env.i18n.default_language}$1`)
-        if(!local && fs.existsSync(i18nPath)) local = i18nPath  // allow fallback i18n
+        if(!locale && options.locale && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`))) local = i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`)
+        // https://cap.cloud.sap/docs/node.js/events#locale => req.locale or old (cds.user.locale)
+        if(!locale && req_locale.default(request) && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) locale = i18nPath.replace(/(\.properties)$/, `_${req_locale.default(request)}$1`)
+        if(!locale && cds.env.i18n.default_language && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) locale = i18nPath.replace(/(\.properties)$/, `_${cds.env.i18n.default_language}$1`)
+        if(!locale && fs.existsSync(i18nPath)) locale = i18nPath  // allow fallback i18n
 
         // use langu from settings options
-        if (local.length > 0){ 
-          i18nPath = local[0]
+        if (locale){ 
+          i18nPath = locale
         } else {
           return cdsLaunchpadLogger.error(`i18n file not found: ${i18nPath}`)
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,14 +192,14 @@ export class cds_launchpad_plugin{
         }
 
         // define local to use
-        const local = []
+        const local = null;
 
         // check for existing files
-        if(options.locale && local.indexOf(options.locale) < 0 && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`)))  local.push(i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`))
-        if(cds.user?.local && local.indexOf(cds.user?.local) < 0 && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`)))  local.push(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`)) // would be great but only exists after CAP logic..
-        if(req_locale.default(request) && local.indexOf(req_locale.default(request)) < 0 && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`)))  local.push(i18nPath.replace(/(\.properties)$/, `_${req_locale.default(request)}$1`)) 
-        if(cds.env.i18n.default_language && local.indexOf(cds.env.i18n.default_language) < 0 && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`)))  local.push(i18nPath.replace(/(\.properties)$/, `_${cds.env.i18n.default_language}$1`)) 
-        if(local.indexOf('') < 0 && fs.existsSync(i18nPath)) local.push(i18nPath)  // allow fallback i18n
+        if(!local && options.locale && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`))) local = i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`)
+        if(!local && cds.user?.local && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) local = i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`) // would be great but only exists after CAP logic..
+        if(!local && req_locale.default(request) && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) local = i18nPath.replace(/(\.properties)$/, `_${req_locale.default(request)}$1`)
+        if(!local && cds.env.i18n.default_language && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) local = i18nPath.replace(/(\.properties)$/, `_${cds.env.i18n.default_language}$1`)
+        if(!local && fs.existsSync(i18nPath)) local = i18nPath  // allow fallback i18n
 
         // use langu from settings options
         if (local.length > 0){ 

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,10 +192,10 @@ export class cds_launchpad_plugin{
         }
 
         // define locale to use
-        const locale = null;
+        let locale = null;
 
         // check for existing files
-        if(!locale && options.locale && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`))) local = i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`)
+        if(!locale && options.locale && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`))) locale = i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`)
         // https://cap.cloud.sap/docs/node.js/events#locale => req.locale or old (cds.user.locale)
         if(!locale && req_locale.default(request) && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) locale = i18nPath.replace(/(\.properties)$/, `_${req_locale.default(request)}$1`)
         if(!locale && cds.env.i18n.default_language && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) locale = i18nPath.replace(/(\.properties)$/, `_${cds.env.i18n.default_language}$1`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,11 +195,10 @@ export class cds_launchpad_plugin{
         let locale = null;
 
         // check for existing files
-        if(!locale && options.locale && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`))) locale = i18nPath.replace(/(\.properties)$/, `_${options.locale}$1`)
-        // https://cap.cloud.sap/docs/node.js/events#locale => req.locale or old (cds.user.locale)
-        if(!locale && req_locale.default(request) && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) locale = i18nPath.replace(/(\.properties)$/, `_${req_locale.default(request)}$1`)
-        if(!locale && cds.env.i18n.default_language && fs.existsSync(i18nPath.replace(/(\.properties)$/, `_${cds.user?.local}$1`))) locale = i18nPath.replace(/(\.properties)$/, `_${cds.env.i18n.default_language}$1`)
-        if(!locale && fs.existsSync(i18nPath)) locale = i18nPath  // allow fallback i18n
+        if (!locale) locale = this.checkI18nFile(i18nPath, options.locale);
+        if (!locale) locale = this.checkI18nFile(i18nPath, req_locale.default(request)); // https://cap.cloud.sap/docs/node.js/events#locale => req.locale or old (cds.user.locale)
+        if (!locale) locale = this.checkI18nFile(i18nPath, cds.env.i18n.default_language);
+        if (!locale && fs.existsSync(i18nPath)) locale = i18nPath; // allow fallback i18n
 
         // use langu from settings options
         if (locale){ 
@@ -267,5 +266,15 @@ export class cds_launchpad_plugin{
       });
 
     return config;
+  }
+	
+ checkI18nFile(i18nPath: String, locale: string){
+    const fileName = i18nPath.replace(/(\.properties)$/, `_${locale}$1`);
+    if(fs.existsSync(fileName)){
+      return fileName;
+    } else{
+      cdsLaunchpadLogger.debug(`could not read i18n file: ${fileName}`)
+    } 
+    return undefined;
   }
 }


### PR DESCRIPTION
maybe this suggestion for issue: #25 is OK?

- we want to use the first valid language
- we should check if the file exists
- if there is no file we should give an error
- if there somedays is a solution to get req.locale (https://cap.cloud.sap/docs/node.js/events#locale)