### PR TITLE
Fix 54912eb3b70a0904b1d53c1462385d73bb20fde7 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,8 @@ export class cds_launchpad_plugin{
 
       // Mount path for launchpad page
       router.use(mount, async (request: express.Request, response: express.Response, next) => {
-        if(request.originalUrl.startsWith(options.basePath)) {
+        const originalUrl = new URL(request.originalUrl, `${request.protocol}://${request.hostname}`);
+        if (originalUrl.pathname === options.basePath) {
           response.send(await this.prepareTemplate(options));
         } else {
             next();


### PR DESCRIPTION
This change will allow us to have both search parameters and default page. Currently if basePath is "" or "/" then all the urls will be caught by "startsWith" approach. This makes requests to `/appconfig/fioriSandboxConfig.json` to return html instead of json, which breaks the launchpad plugin behavior. 