### PR TITLE
fix - load correct cds.env for the project path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export class cds_launchpad_plugin{
       cdsLaunchpadLogger.debug('Sandbox launchpad not initialized as the process runs in production ')
       return
     }
+    // Load correct env for project path
+    cds.env = cds.env.for("cds", cds.root ?? process.cwd());
     let options: LaunchpadConfig = cds.env.launchpad;
     const router = express.Router();
 
@@ -48,6 +50,8 @@ export class cds_launchpad_plugin{
         response.send(await this.prepareAppConfigJSON(options));
       });
 
+      // Load correct env for project path
+      cds.env = cds.env.for("cds", cds.root ?? process.cwd());
       // Component preload generation
       const componentPreloadCache = new Map()
       const _componentPreload = async (appName: String) => {
@@ -148,7 +152,8 @@ export class cds_launchpad_plugin{
 
     // merge the two
     Object.assign(config, extConfig);
-
+    // Load correct env for project path
+    cds.env = cds.env.for("cds", cds.root ?? process.cwd());
     // Read CDS project package
     const packagejson = JSON.parse(fs.readFileSync(cds.root + '/package.json').toString());
     let depsPaths = [];


### PR DESCRIPTION
When various plugins load @sap/cds the env can become invalid and set to defaults rather than the project specific values. 
Before accessing cds.env it should be reloaded for the CAP project root for more reliable access. 
Add compatibility with @sap/ux-ui5-tooling >= 0.14.5 and @sap/cds 8.