### PR TITLE
Fix regex replacement for API path mounting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export class cds_launchpad_plugin{
 
     cds.on('serving', async (service) => {
       const apiPath = options.basePath;
-      const mount = apiPath.replace('$','[\\$]')
+      const mount = apiPath
       cdsLaunchpadLogger._debug && cdsLaunchpadLogger.debug ('serving launchpad for ', {service: service.name, at: apiPath})
 
       // Mount path for launchpad page


### PR DESCRIPTION
`cds-launchpad-plugin` fails on startup with the following error when used alongside `router` v2.x, which depends on `path-to-regexp` v8+:                                                                                        
                                                                                                                                                                                                                                    
  TypeError: Unexpected [ at index 1, expected end: /[$]launchpad

  The error is thrown in `setup()` where the `apiPath` is transformed using:

  ```js
  const mount = apiPath.replace('$', '[\\$]');
  ```

  This produces a route path like /[$]launchpad. In path-to-regexp v8, bracket notation ([...]) is no longer supported as a character class — [ is now a reserved token that throws a PathError when encountered in a route string.

  **Fix**

  In path-to-regexp v8+, $ is treated as a plain character (not a special token), so no escaping or substitution is needed. The replacement can simply be removed:

  ```js
  const mount = apiPath;
  ```